### PR TITLE
Making log_path configuration optinal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Reads and parses the /admin/systeminfo.xml page and exports the number of proces
     * *tableau_user* and *tableau_password*: a Tableau Server user with administrative privileges
     * *api_version*: REST API version for the Tableau Server version. See https://onlinehelp.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm
     * *server_host*: Tableau Server hostname, starting with http(s)://
-    * *site*: The Tableau site to use
+    * *site*: The Tableau site to use (if empty, Default site is used)
     * *exporter_port*: Which port to use for the exporter's webserver
-    * *log_path*: Where to store logs
+    * *log_path* (optional): File to output logs to (if missing or empty, logs go to stdout)
 3. Install with `pip install <path_to_project>`. Dependencies:
     * *pyyaml*: YAML config processing
     * *requests*: Accessing the Tableau Server REST API (for login) and the systeminfo.xml page

--- a/executable/main.py
+++ b/executable/main.py
@@ -12,10 +12,15 @@ if __name__ == '__main__':
     with open(args.config_file, "r") as config:
         conf = yaml.load(config)
 
-    logging.basicConfig(filename=conf['log_path'],
-                        filemode='a',
-                        format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
-                        datefmt='%H:%M:%S',
-                        level=logging.INFO)
+    if 'log_path' in conf and conf['log_path'] != '':
+        logging.basicConfig(filename=conf['log_path'],
+                            filemode='a',
+                            format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+                            datefmt='%H:%M:%S',
+                            level=logging.INFO)
+    else:
+        logging.basicConfig(format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+                            datefmt='%H:%M:%S',
+                            level=logging.INFO)
 
     start_webserver(conf)


### PR DESCRIPTION
I am containerizing this exporter, and would like logs to go to stdout. This change makes the log_path configuration optional: if it is either missing or empty, logs go to stdout. 