### PR TITLE
Add token and verify SSL configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Reads and parses the /admin/systeminfo.xml page and exports the number of proces
     * *site*: The Tableau site to use (if empty, Default site is used)
     * *exporter_port*: Which port to use for the exporter's webserver
     * *log_path* (optional): File to output logs to (if missing or empty, logs go to stdout)
-    * *verify_ssl* (optional): Verify SSL request when fetching status from Tableau, defaults to true.
+    * *verify_ssl* (optional): Verify SSL request when fetching status from Tableau, defaults to false.
 3. Install with `pip install <path_to_project>`. Dependencies:
     * *pyyaml*: YAML config processing
     * *requests*: Accessing the Tableau Server REST API (for login) and the systeminfo.xml page

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Reads and parses the /admin/systeminfo.xml page and exports the number of proces
 
 1. Clone the project
 2. Create config file based on config.yml.template. Configs:
-    * *tableau_user* and *tableau_password*: a Tableau Server user with administrative privileges
+    * *tableau_user* and *tableau_password*: credentials for a Tableau Server user with administrative privileges (alternative to token)
+    * *tableau_token_name* and *tableau_token_secret*: personal access token for a Tableau Server user with administrative privileges (alternative to user/password)
     * *api_version*: REST API version for the Tableau Server version. See https://onlinehelp.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_versions.htm
     * *server_host*: Tableau Server hostname, starting with http(s)://
     * *site*: The Tableau site to use (if empty, Default site is used)
     * *exporter_port*: Which port to use for the exporter's webserver
     * *log_path* (optional): File to output logs to (if missing or empty, logs go to stdout)
+    * *verify_ssl* (optional): Verify SSL request when fetching status from Tableau, defaults to true.
 3. Install with `pip install <path_to_project>`. Dependencies:
     * *pyyaml*: YAML config processing
     * *requests*: Accessing the Tableau Server REST API (for login) and the systeminfo.xml page

--- a/config.yml.template
+++ b/config.yml.template
@@ -1,5 +1,8 @@
 tableau_user: ''
 tableau_password: ''
+# Personal access token alternative to user/password
+# tableau_token_name: ''
+# tableau_token_secret: ''
 api_version: '3.1'
 server_host: 'http://tableau-server.host'
 site: ''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 NAME = "tableau-exporter"
 
-VERSION = "0.1.2"
+VERSION = "0.2.0"
 
 REQUIRES = [
     "pyyaml",

--- a/tableau_exporter/tableau_status_exporter.py
+++ b/tableau_exporter/tableau_status_exporter.py
@@ -13,7 +13,7 @@ import xml.etree.ElementTree as ET
 logger = logging.getLogger(__name__)
 
 class TokenManager(object):
-    def __init__(self, host, api_version, site, user, password, token_name, token_secret):
+    def __init__(self, user, password, site, host, api_version, token_name=None, token_secret=None):
         self._token = None
         self._api_version = api_version
         self.host = host
@@ -64,7 +64,7 @@ class TokenManager(object):
 
 class TableauMetricsCollector(object):
     '''collection of metrics for prometheus'''
-    def __init__(self, token_manager, verify_ssl=True):
+    def __init__(self, token_manager, verify_ssl=False):
         logger.info('Initializing metrics collector')
         self.token_manager = token_manager
         self.verify_ssl = verify_ssl
@@ -103,10 +103,9 @@ class TableauMetricsCollector(object):
 def start_webserver(conf):
 
     token_manager = TokenManager(
-        conf['server_host'], conf['api_version'], conf['site'],
-        conf.get('tableau_user'), conf.get('tableau_password'), conf.get('tableau_token_name'),
-        conf.get('tableau_token_secret'))
-    REGISTRY.register(TableauMetricsCollector(token_manager, verify_ssl=conf.get('verify_ssl', True)))
+        conf.get('tableau_user'), conf.get('tableau_password'), conf['site'], conf['server_host'], conf['api_version'],
+        token_name=conf.get('tableau_token_name'), token_secret=conf.get('tableau_token_secret'))
+    REGISTRY.register(TableauMetricsCollector(token_manager, verify_ssl=conf.get('verify_ssl', False)))
 
     # Start up the server to expose the metrics.
     root = Resource()

--- a/tests/unit/test_server_parse_status_metrics.py
+++ b/tests/unit/test_server_parse_status_metrics.py
@@ -36,5 +36,4 @@ class TestTableauServerStatusParser(unittest.TestCase):
         xml_response = self.init_default_check()
         got = TableauServerStatusParser.tableau_server_parse_status_metrics(xml_response=xml_response[0])
         expected = 'tableau_server_process_status'
-        print(expected)
         self.assertEqual(expected, got.name)

--- a/tests/unit/test_server_parse_status_metrics.py
+++ b/tests/unit/test_server_parse_status_metrics.py
@@ -36,5 +36,5 @@ class TestTableauServerStatusParser(unittest.TestCase):
         xml_response = self.init_default_check()
         got = TableauServerStatusParser.tableau_server_parse_status_metrics(xml_response=xml_response[0])
         expected = 'tableau_server_process_status'
-        print expected
+        print(expected)
         self.assertEqual(expected, got.name)


### PR DESCRIPTION
Along with https://github.com/hellofresh/tableau-status-exporter/pull/17, we made a couple changes to make this work for us: 

1. Support authentication via [Personal Access Tokens](https://help.tableau.com/current/server/en-us/security_personal_access_tokens.htm).
2. Make status request with SSL verification.

Both are configurable so previous usage is still available. Note I got this working on Tableau Server 2020.2 and Python 3.7.